### PR TITLE
docs(README): Use correct FluidEvents.interact method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Examples
 
 //startup
-FluidEvents.register(event => {
+FluidEvents.interact(event => {
 
     //the most literal methods that you can achieve your own ideas about fluid interact with fluid, block, and even entity!
     event.create(


### PR DESCRIPTION
The example in the README was using `FluidEvents.register`, which is incorrect for this type of event and would cause errors.

This commit updates the example to use the correct `FluidEvents.interact` method, ensuring users can copy and use the code successfully.